### PR TITLE
fixed the object object has no attribute is_integer for drawinf  BEV …

### DIFF
--- a/bbox3d_utils.py
+++ b/bbox3d_utils.py
@@ -659,7 +659,8 @@ class BirdEyeView:
         
         # Draw distance markers specifically for 1-5 meter range
         # Use fixed steps of 1 meter with intermediate markers at 0.5 meters
-        for dist in [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]:
+        
+        for dist in [1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]: #fix for BEV object has no attribute
             y = self.origin_y - int(dist * self.scale)
             
             if y < 20:  # Skip if too close to top


### PR DESCRIPTION
…in bbox3d_utils.py line 663 by making all the content of the arrays float instead of mix of float and integer
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `AttributeError` in `reset()` in `bbox3d_utils.py` by converting distance markers to floats.
> 
>   - **Behavior**:
>     - Fixes `AttributeError` in `reset()` in `bbox3d_utils.py` by converting distance markers to floats.
>     - Ensures all distance values in the list are floats to prevent `is_integer` attribute error.
>   - **Misc**:
>     - Adds newline at end of file in `bbox3d_utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=niconielsen32%2FYOLO-3D&utm_source=github&utm_medium=referral)<sup> for 55b0e931d6fe5e1af886353cdfcf37608b3f9597. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->