### PR TITLE
Bug fix!

### DIFF
--- a/bbox3d_utils.py
+++ b/bbox3d_utils.py
@@ -666,17 +666,17 @@ class BirdEyeView:
                 continue
             
             # Draw tick mark - thicker for whole meters
-            thickness = 2 if dist.is_integer() else 1
+            thickness = 2 if dist == int(dist) else 1
             cv2.line(self.bev_image, 
                     (self.origin_x - 5, y), 
                     (self.origin_x + 5, y), 
                     (120, 120, 120), thickness)
             
             # Only show text for whole meters
-            if dist.is_integer():
+            if dist == int(dist):
                 cv2.putText(self.bev_image, f"{int(dist)}m", 
-                           (self.origin_x + 10, y + 4), 
-                           cv2.FONT_HERSHEY_SIMPLEX, 0.4, (180, 180, 180), 1)
+                        (self.origin_x + 10, y + 4), 
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.4, (180, 180, 180), 1)
     
     def draw_box(self, box_3d, color=None):
         """


### PR DESCRIPTION
Fixed the bug: Error drawing BEV: 'int' object has no attribute 'is_integer'
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `BirdEyeView` class by replacing `is_integer()` with `dist == int(dist)` to correctly draw whole meter tick marks and text.
> 
>   - **Bug Fix**:
>     - Fixes bug in `BirdEyeView` class in `bbox3d_utils.py` where `is_integer()` was incorrectly used on an `int` object.
>     - Replaces `is_integer()` with `dist == int(dist)` to correctly determine whole meters for tick marks and text in BEV visualization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=niconielsen32%2FYOLO-3D&utm_source=github&utm_medium=referral)<sup> for 044fe466c4a7b17f3f43af6eed36e65da0ac5038. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->