### PR TITLE
Fix: handle int/float for is_integer in BEV drawing

### DIFF
--- a/bbox3d_utils.py
+++ b/bbox3d_utils.py
@@ -666,14 +666,14 @@ class BirdEyeView:
                 continue
             
             # Draw tick mark - thicker for whole meters
-            thickness = 2 if dist.is_integer() else 1
+            thickness = 2 if float(dist).is_integer() else 1
             cv2.line(self.bev_image, 
                     (self.origin_x - 5, y), 
                     (self.origin_x + 5, y), 
                     (120, 120, 120), thickness)
             
             # Only show text for whole meters
-            if dist.is_integer():
+            if float(dist).is_integer():
                 cv2.putText(self.bev_image, f"{int(dist)}m", 
                            (self.origin_x + 10, y + 4), 
                            cv2.FONT_HERSHEY_SIMPLEX, 0.4, (180, 180, 180), 1)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `is_integer` check in `BirdEyeView.reset()` by converting `dist` to `float`, affecting BEV visualization tick marks and text.
> 
>   - **Behavior**:
>     - Fixes `is_integer` check in `BirdEyeView.reset()` by converting `dist` to `float` before calling `is_integer()`.
>     - Affects drawing of tick marks and text for whole meters in BEV visualization.
>   - **Misc**:
>     - No other changes or additions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=niconielsen32%2FYOLO-3D&utm_source=github&utm_medium=referral)<sup> for a896ffc08426ca637419625945c3c8a9f12d5f61. You can [customize](https://app.ellipsis.dev/niconielsen32/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->